### PR TITLE
Move Encoded frame timestamps to Metadata dicts and rename to rtpTimestamp

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -332,6 +332,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
     long long timestamp;    // microseconds
+    long long rtpTimestamp;
 };
 </pre>
 
@@ -376,6 +377,16 @@ dictionary RTCEncodedVideoFrameMetadata {
 	    {{VideoFrame/timestamp}} for raw frames which correspond to this frame.
         </p>
     </dd>
+    <dt>
+        <dfn>rtpTimestamp</dfn> of type <span class=
+            "idlMemberType">unsigned long</span>
+    </dt>
+    <dd>
+        <p>
+	    The RTP timestamp identifier is an unsigned integer value per [RFC3550] that
+	    reflects the sampling instant of the first octet in the RTP data packet.
+        </p>
+    </dd>
 </dl>
 
 
@@ -386,7 +397,6 @@ dictionary RTCEncodedVideoFrameMetadata {
 [Exposed=(Window,DedicatedWorker)]
 interface RTCEncodedVideoFrame {
     readonly attribute RTCEncodedVideoFrameType type;
-    readonly attribute unsigned long timestamp;
     attribute ArrayBuffer data;
     RTCEncodedVideoFrameMetadata getMetadata();
 };
@@ -403,16 +413,6 @@ interface RTCEncodedVideoFrame {
         <p>
             The type attribute allows the application to determine when a key frame is being
             sent or received.
-        </p>
-    </dd>
-
-    <dt>
-        <dfn>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
-    </dt>
-    <dd>
-        <p>
-            The RTP timestamp identifier is an unsigned integer value per [[RFC3550]]
-            that reflects the sampling instant of the first octet in the RTP data packet.
         </p>
     </dd>
     <dt>
@@ -446,6 +446,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
     short sequenceNumber;
+    unsigned long rtpTimestamp;
 };
 </pre>
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}
@@ -491,13 +492,21 @@ dictionary RTCEncodedAudioFrameMetadata {
             Comparing two sequence numbers requires serial number arithmetic described in [[RFC1982]].
         </p>
     </dd>
+    <dt>
+        <dfn>rtpTimestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
+    </dt>
+    <dd>
+        <p>
+            The RTP timestamp identifier is an unsigned integer value per [[RFC3550]]
+            that reflects the sampling instant of the first octet in the RTP data packet.
+        </p>
+    </dd>
 </dl>
 
 ## <dfn>RTCEncodedAudioFrame</dfn> interface ## {#RTCEncodedAudioFrame-interface}
 <pre class="idl">
 [Exposed=(Window,DedicatedWorker)]
 interface RTCEncodedAudioFrame {
-    readonly attribute unsigned long timestamp;
     attribute ArrayBuffer data;
     RTCEncodedAudioFrameMetadata getMetadata();
 };
@@ -507,15 +516,6 @@ interface RTCEncodedAudioFrame {
 <dl data-link-for="RTCEncodedAudioFrame"
         data-dfn-for="RTCEncodedAudioFrame"
         class="dictionary-members">
-    <dt>
-        <dfn>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
-    </dt>
-    <dd>
-        <p>
-            The RTP timestamp identifier is an unsigned integer value per [[RFC3550]]
-            that reflects the sampling instant of the first octet in the RTP data packet.
-        </p>
-    </dd>
     <dt>
         <dfn>data</dfn> of type <span class="idlMemberType">ArrayBuffer</span>
     </dt>

--- a/index.bs
+++ b/index.bs
@@ -331,7 +331,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     unsigned long synchronizationSource;
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
-    long long presentationTimestamp;    // microseconds
+    long long timestamp;    // microseconds
 };
 </pre>
 
@@ -367,7 +367,7 @@ dictionary RTCEncodedVideoFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn>presentationTimestamp</dfn> of type <span class=
+        <dfn>timestamp</dfn> of type <span class=
             "idlMemberType">long long</span>
     </dt>
     <dd>


### PR DESCRIPTION
A potential followup to https://github.com/w3c/webrtc-encoded-transform/pull/173, ensuring we only have a single field related to an encoded frame with the name "timestamp", and there's less incompatibility between our encoded frames and WebCodec's due to misaligned timestamp definitions.